### PR TITLE
Add modular Discord bot scaffold with slash commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DISCORD_TOKEN=your_token_here
+OWNER_ID=your_discord_id_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # OPBot
+
+Simple Discord bot built with Node.js and discord.js. Uses slash commands and a modular file structure. Slash commands are registered for each guild on startup so outdated commands are removed automatically.
+
+## Setup
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+2. Create a `.env` file based on `.env.example` and set `DISCORD_TOKEN` and `OWNER_ID`.
+3. Start the bot:
+   ```
+   node index.js
+   ```
+
+## Structure
+
+- `commands/` – categorized slash commands (`mod`, `fun`, `admin`, `botowner`)
+- `events/` – event handlers like `ready`
+- `interaction/` – interaction handler for executing commands

--- a/commands/admin/say.js
+++ b/commands/admin/say.js
@@ -1,0 +1,15 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('say')
+    .setDescription('Replies with your input.')
+    .addStringOption(option =>
+      option.setName('message').setDescription('The message to send').setRequired(true)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  async execute(interaction) {
+    const message = interaction.options.getString('message');
+    await interaction.reply({ content: message });
+  },
+};

--- a/commands/botowner/eval.js
+++ b/commands/botowner/eval.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('eval')
+    .setDescription('Evaluates JavaScript code (bot owner only)')
+    .addStringOption(option =>
+      option.setName('code').setDescription('The code to evaluate').setRequired(true)
+    ),
+  async execute(interaction) {
+    if (interaction.user.id !== process.env.OWNER_ID) {
+      return interaction.reply({ content: 'You cannot use this command.', ephemeral: true });
+    }
+    const code = interaction.options.getString('code');
+    try {
+      const result = eval(code);
+      await interaction.reply({ content: `Result: ${result}`, ephemeral: true });
+    } catch (err) {
+      await interaction.reply({ content: `Error: ${err}`, ephemeral: true });
+    }
+  },
+};

--- a/commands/fun/ping.js
+++ b/commands/fun/ping.js
@@ -1,0 +1,10 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Replies with Pong!'),
+  async execute(interaction) {
+    await interaction.reply('Pong!');
+  },
+};

--- a/commands/mod/kick.js
+++ b/commands/mod/kick.js
@@ -1,0 +1,15 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('kick')
+    .setDescription('Kicks a member from the server.')
+    .addUserOption(option =>
+      option.setName('target').setDescription('The member to kick').setRequired(true)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+  async execute(interaction) {
+    const user = interaction.options.getUser('target');
+    await interaction.reply(`Pretending to kick ${user.tag}.`);
+  },
+};

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,0 +1,11 @@
+const { Events } = require('discord.js');
+
+module.exports = {
+  name: Events.GuildCreate,
+  async execute(guild, client) {
+    const commands = client.commands.map(cmd => cmd.data.toJSON());
+    await guild.commands.set([]);
+    await guild.commands.set(commands);
+    console.log(`Registered commands for new guild ${guild.name}`);
+  },
+};

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,0 +1,16 @@
+const { Events } = require('discord.js');
+
+module.exports = {
+  name: Events.ClientReady,
+  once: true,
+  async execute(client) {
+    const commands = client.commands.map(cmd => cmd.data.toJSON());
+    for (const guild of client.guilds.cache.values()) {
+      await guild.commands.set([]);
+      await guild.commands.set(commands);
+    }
+    console.log(
+      `Ready! Logged in as ${client.user.tag} in ${client.guilds.cache.size} guild(s)`
+    );
+  },
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { Client, Collection, GatewayIntentBits } = require('discord.js');
+const { Events } = require('discord.js');
+require('dotenv').config();
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+client.commands = new Collection();
+
+const commandsPath = path.join(__dirname, 'commands');
+const commandFolders = fs.readdirSync(commandsPath);
+for (const folder of commandFolders) {
+  const folderPath = path.join(commandsPath, folder);
+  const commandFiles = fs.readdirSync(folderPath).filter(file => file.endsWith('.js'));
+  for (const file of commandFiles) {
+    const filePath = path.join(folderPath, file);
+    const command = require(filePath);
+    if ('data' in command && 'execute' in command) {
+      client.commands.set(command.data.name, command);
+    } else {
+      console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+    }
+  }
+}
+
+const eventsPath = path.join(__dirname, 'events');
+const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));
+for (const file of eventFiles) {
+  const filePath = path.join(eventsPath, file);
+  const event = require(filePath);
+  if (event.once) {
+    client.once(event.name, (...args) => event.execute(...args, client));
+  } else {
+    client.on(event.name, (...args) => event.execute(...args, client));
+  }
+}
+
+require('./interaction/interactionEvent')(client);
+
+client.login(process.env.DISCORD_TOKEN);

--- a/interaction/interactionEvent.js
+++ b/interaction/interactionEvent.js
@@ -1,0 +1,19 @@
+const { Events } = require('discord.js');
+
+module.exports = client => {
+  client.on(Events.InteractionCreate, async interaction => {
+    if (!interaction.isChatInputCommand()) return;
+    const command = client.commands.get(interaction.commandName);
+    if (!command) return;
+    try {
+      await command.execute(interaction);
+    } catch (error) {
+      console.error(error);
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
+      } else {
+        await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "opbot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.13.0",
+    "dotenv": "^16.3.1"
+  }
+}


### PR DESCRIPTION
## Summary
- register slash commands per guild and purge outdated commands on startup
- handle new guild joins by syncing slash commands
- document per-guild command registration and add required dependencies

## Testing
- `node --check index.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0754c75fc832e8f5056a6ef04413d